### PR TITLE
Update : Enum recherche value par traduction 

### DIFF
--- a/publishables/database/migrations/2023_03_30_121103_create_countries.php
+++ b/publishables/database/migrations/2023_03_30_121103_create_countries.php
@@ -17,7 +17,7 @@ return new class extends Migration {
             $table->longText('name')->nullable();
         });
 
-        if (!\MetaFramework\Accessors\Locale::multilang()) {
+        if (\MetaFramework\Accessors\Locale::multilang()) {
 
 
             $sql = "INSERT INTO `countries` (`id`, `code`, `name`) VALUES

--- a/src/Traits/BackedEnum.php
+++ b/src/Traits/BackedEnum.php
@@ -30,7 +30,12 @@ trait BackedEnum
                 collect($keys)->map(fn($item) => trans('enum.' . static::varname() . '.' . $item))->toArray()
             );
         });
+    }
 
-
+    public static function getValueFromTranslation(string $keyword): bool|string
+    {
+        return collect(self::translations())->search(function ($item, $key) use ($keyword) {
+            return strtolower($item) == strtolower($keyword);
+        });
     }
 }


### PR DESCRIPTION
+ Mini fix migration multilangue inversé :
J'avais copier la migration et du coup était en "multilang" dans la bdd sur les countries alors que non. 
Le check était bon par la suite ailleur le metaframework il cherché une valeur sans json car non multilangue