### PR TITLE
Fix : Validation id dois pas finir par un "." dans le cas name="nom_i…

### DIFF
--- a/src/Components/Radio.php
+++ b/src/Components/Radio.php
@@ -4,20 +4,28 @@ namespace MetaFramework\Components;
 
 use Illuminate\Contracts\Support\Renderable;
 use Illuminate\View\Component;
+use MetaFramework\Functions\Helpers;
 
 class Radio extends Component
 {
+    private string $validation_id;
+
     public function __construct(
-        public array $values,
-        public string $name,
+        public array           $values,
+        public string          $name,
         public int|string|null $affected,
-        public string|null $label = '',
+        public string|null     $label = '',
         public int|string|null $default = null
     )
-    {}
+    {
+        $this->validation_id = Helpers::generateValidationId($this->name);
+    }
 
     public function render(): Renderable
     {
-        return view('mfw::components.radio');
+        return view('mfw::components.radio')
+            ->with([
+                'validation_id' => $this->validation_id,
+            ]);
     }
 }

--- a/src/Functions/Helpers.php
+++ b/src/Functions/Helpers.php
@@ -11,6 +11,6 @@ class Helpers
 
     public static function generateValidationId(string $string): string
     {
-        return str_replace(['[', ']'], ['.', ''], $string);
+        return rtrim(str_replace(['[', ']'], ['.', ''], $string), '.');
     }
 }

--- a/src/Resources/views/components/radio.blade.php
+++ b/src/Resources/views/components/radio.blade.php
@@ -8,3 +8,4 @@
         {{ __('mfw.no_data_provided') }}
     @endforelse
 </div>
+<x-mfw::validation-error :field="$validation_id"/>


### PR DESCRIPTION
Validation id dois pas finir par un "." dans le cas name="nom_input[wagaia][]" les erreurs sont sur nom_input.wagaia (pas de . a la fin) + ajout des erreurs sur le component radio