### PR TITLE
Fix : Price readable format

### DIFF
--- a/src/Accessors/Prices.php
+++ b/src/Accessors/Prices.php
@@ -23,8 +23,8 @@ class Prices
         return (int)round($price);
     }
 
-    public static function readableFormat(int|float $price, string $currency = '€'): string
+    public static function readableFormat(int|float $price, string $currency = '€', string $decimal_separator = ',', string $thousand_separator = ' '): string
     {
-        return rtrim(number_format($price, 0, ' ') . ' '.$currency);
+        return rtrim(number_format($price, 2, $decimal_separator, $thousand_separator) . ' '.$currency);
     }
 }


### PR DESCRIPTION
Le format était pas "bon" un espace pour les centimes & le "," pour les milliers

Format FR par défault ',' pour centime & espace pour les 1 000

je les ai rajouté en params du format en optionnel ca peut etre utile sinon corrige les dans la fonction